### PR TITLE
Replace Flutter dependencies with Meta dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,23 +1,9 @@
-## 0.0.1
-* Implementation of the RCON protocol. Contains full API.
+## 1.2.0
 
-## 0.0.2
-* Fixed a typo in the README.
-
-## 1.0.0
-* Fixed some debug print lines. Tested package and full API is operational.
-
-## 1.0.1
-* Fixed example Dart file name to match pub.dev requirement. (This was a lie.)
-* Removed Flutter dependency.
-
-## 1.0.2
-* Actually renamed the example file...
-
-## 1.0.3
-* Something funky happened with the upload of the last version. Trying again...
+* Replaced the Flutter dependency with a meta dependency. The declaration of the annotations is in that package.
 
 ## 1.1.0
+
 * Refactored basically every function and split them into many more functions.
 * Added a whole lot of comments to go with that refactoring.
 * Also added DartDocs to the new functions (but those are all private... so you may never see them :P)
@@ -26,3 +12,28 @@
 * Modified the README usage section.
 * Added Flutter dependency (required for function annotations).
 * Added unit tests. THESE ARE NOT DONE. I AM NOT GOING TO WRITE MORE. AT LEAST NOT RIGHT NOW. I DO NOT HAVE THE WILLPOWER TO DO THIS ANY LONGER. Please send help.
+
+## 1.0.3
+
+* Something funky happened with the upload of the last version. Trying again...
+
+## 1.0.2
+
+* Actually renamed the example file...
+
+## 1.0.1
+
+* Fixed example Dart file name to match pub.dev requirement. (This was a lie.)
+* Removed Flutter dependency.
+
+## 1.0.0
+
+* Fixed some debug print lines. Tested package and full API is operational.
+
+## 0.0.2
+
+* Fixed a typo in the README.
+
+## 0.0.1
+
+* Implementation of the RCON protocol. Contains full API.

--- a/example/example.dart
+++ b/example/example.dart
@@ -1,4 +1,3 @@
-import 'dart:typed_data';
 import 'package:mc_rcon_dart/mc_rcon_dart.dart';
 
 main() async {

--- a/lib/src/rcon_helpers.dart
+++ b/lib/src/rcon_helpers.dart
@@ -1,5 +1,6 @@
 import 'dart:typed_data';
-import 'package:flutter/foundation.dart';
+
+import 'package:meta/meta.dart';
 
 import 'rcon_vars.dart';
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mc_rcon_dart
 description: A Dart SDK for interacting with a Minecraft server using the RCON protocol.
-version: 1.1.0
+version: 1.2.0
 homepage: https://github.com/aidanlok/mc_rcon
 repository: https://github.com/aidanlok/mc_rcon
 issue_tracker: https://github.com/aidanlok/mc_rcon/issues

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,12 +6,11 @@ repository: https://github.com/aidanlok/mc_rcon
 issue_tracker: https://github.com/aidanlok/mc_rcon/issues
 
 environment:
-  sdk: '>=2.17.1 <3.0.0'
+  sdk: '>=2.17.1 <4.0.0'
+
+dependencies:
+  meta: ^1.0.2
 
 dev_dependencies:
   lints: ^2.0.0
   test: ^1.21.6
-
-dependencies:
-  flutter:
-    sdk: flutter

--- a/test/mc_rcon_dart_test.dart
+++ b/test/mc_rcon_dart_test.dart
@@ -1,7 +1,5 @@
-import 'dart:ffi';
 import 'dart:math';
 
-import 'package:flutter/foundation.dart';
 import 'package:test/test.dart';
 import 'dart:typed_data';
 import 'package:mc_rcon_dart/mc_rcon_dart.dart' as mc_rcon;


### PR DESCRIPTION
Hello! Thanks for the package!

I've replaced the Flutter dependency with a `meta` (see [here](https://pub.dev/packages/meta) dependency since the annotations are declared there originally and only exported through the Flutter foundation. I was also extra careful in the versioning by placing the minimum version exactly when both used annotations exist, so older projects run as they are supposed to.

I've also removed some unused imports and sorted the Changelog the other way around, so when others get to your package, they don't need to scroll down to see the latest changes.

I've updated a minor version since this changes a dependency and may have some effect there, but this breaks nothing.