### PR TITLE
Updates type for `onData` callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.3.0
+
+* Created a typedef for the onData callback to make it easier to use. It already expects the correct parameters.
+
 ## 1.2.0
 
 * Replaced the Flutter dependency with a meta dependency. The declaration of the annotations is in that package.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 1.3.0
 
 * Created a typedef for the onData callback to make it easier to use. It already expects the correct parameters.
+* Added a new function `listenCancelable` that allows you to cancel the subscription to the stream if you want to. This is useful if you only want to listen for a specific ammount of packets and then stop listening.
 
 ## 1.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,23 +1,9 @@
-## 0.0.1
-* Implementation of the RCON protocol. Contains full API.
+## 1.2.0
 
-## 0.0.2
-* Fixed a typo in the README.
-
-## 1.0.0
-* Fixed some debug print lines. Tested package and full API is operational.
-
-## 1.0.1
-* Fixed example Dart file name to match pub.dev requirement. (This was a lie.)
-* Removed Flutter dependency.
-
-## 1.0.2
-* Actually renamed the example file...
-
-## 1.0.3
-* Something funky happened with the upload of the last version. Trying again...
+* Replaced the Flutter dependency with a meta dependency. The declaration of the annotations is in that package.
 
 ## 1.1.0
+
 * Refactored basically every function and split them into many more functions.
 * Added a whole lot of comments to go with that refactoring.
 * Also added DartDocs to the new functions (but those are all private... so you may never see them :P)
@@ -26,3 +12,28 @@
 * Modified the README usage section.
 * Added Flutter dependency (required for function annotations).
 * Added unit tests. THESE ARE NOT DONE. I AM NOT GOING TO WRITE MORE. AT LEAST NOT RIGHT NOW. I DO NOT HAVE THE WILLPOWER TO DO THIS ANY LONGER. Please send help.
+
+## 1.0.3
+
+* Something funky happened with the upload of the last version. Trying again...
+
+## 1.0.2
+
+* Actually renamed the example file...
+
+## 1.0.1
+
+* Fixed example Dart file name to match pub.dev requirement. (This was a lie.)
+* Removed Flutter dependency.
+
+## 1.0.0
+
+* Fixed some debug print lines. Tested package and full API is operational.
+
+## 0.0.2
+
+* Fixed a typo in the README.
+
+## 0.0.1
+
+* Implementation of the RCON protocol. Contains full API.

--- a/example/example.dart
+++ b/example/example.dart
@@ -1,4 +1,3 @@
-import 'dart:typed_data';
 import 'package:mc_rcon_dart/mc_rcon_dart.dart';
 
 main() async {

--- a/lib/src/rcon_api.dart
+++ b/lib/src/rcon_api.dart
@@ -69,7 +69,7 @@ bool sendCommand(String command) {
 /// server. Returns a boolean that specifies if the socket has
 /// started listening. Note: onData must accept a List<int> and
 /// a String as the only parameters.
-bool listen(Function onData) {
+bool listen(OnDataCallback onData) {
   // Checks to ensure that the RCON socket exists.
   if (rconSck == null) {
     return false;

--- a/lib/src/rcon_helpers.dart
+++ b/lib/src/rcon_helpers.dart
@@ -4,6 +4,11 @@ import 'package:meta/meta.dart';
 
 import 'rcon_vars.dart';
 
+typedef OnDataCallback = void Function(
+  List<int> headers,
+  String payload,
+);
+
 /// Returns a Uint8Lit that contains only 4 integers starting
 /// from original[start]. Start defaults to 0 if not set. If
 /// 4 integers cannot be copied from the list (e.g. list length
@@ -139,7 +144,7 @@ bool _processResponseID(int respID) {
 
 /// Processes the server response (represented as a Uint8List)
 /// and calls onData handler if we have received a good packet.
-void _processServerResponse(Uint8List data, Function onData) {
+void _processServerResponse(Uint8List data, OnDataCallback onData) {
   // Parses out the message headers and payload.
   List<int> rconHeaders = _processHeaders(data);
   String payload = String.fromCharCodes(data, 12);
@@ -164,14 +169,14 @@ void _processServerResponse(Uint8List data, Function onData) {
 /// Processes the server response (represented as a Uint8List)
 /// and calls onData handler if we have received a good packet.
 @visibleForTesting
-void processServerResponse(Uint8List data, Function onData) {
+void processServerResponse(Uint8List data, OnDataCallback onData) {
   return _processServerResponse(data, onData);
 }
 
 /// Processes the server response (represented as a Uint8List)
 /// and calls onData handler if we have received a good packet.
 @protected
-void pSR(Uint8List data, Function onData) {
+void pSR(Uint8List data, OnDataCallback onData) {
   return _processServerResponse(data, onData);
 }
 

--- a/lib/src/rcon_helpers.dart
+++ b/lib/src/rcon_helpers.dart
@@ -1,5 +1,6 @@
 import 'dart:typed_data';
-import 'package:flutter/foundation.dart';
+
+import 'package:meta/meta.dart';
 
 import 'rcon_vars.dart';
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mc_rcon_dart
 description: A Dart SDK for interacting with a Minecraft server using the RCON protocol.
-version: 1.1.0
+version: 1.2.0
 homepage: https://github.com/aidanlok/mc_rcon
 repository: https://github.com/aidanlok/mc_rcon
 issue_tracker: https://github.com/aidanlok/mc_rcon/issues

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,12 +6,11 @@ repository: https://github.com/aidanlok/mc_rcon
 issue_tracker: https://github.com/aidanlok/mc_rcon/issues
 
 environment:
-  sdk: '>=2.17.1 <3.0.0'
+  sdk: '>=2.17.1 <4.0.0'
+
+dependencies:
+  meta: ^1.0.2
 
 dev_dependencies:
   lints: ^2.0.0
   test: ^1.21.6
-
-dependencies:
-  flutter:
-    sdk: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mc_rcon_dart
 description: A Dart SDK for interacting with a Minecraft server using the RCON protocol.
-version: 1.2.0
+version: 1.3.0
 homepage: https://github.com/aidanlok/mc_rcon
 repository: https://github.com/aidanlok/mc_rcon
 issue_tracker: https://github.com/aidanlok/mc_rcon/issues

--- a/test/mc_rcon_dart_test.dart
+++ b/test/mc_rcon_dart_test.dart
@@ -1,7 +1,5 @@
-import 'dart:ffi';
 import 'dart:math';
 
-import 'package:flutter/foundation.dart';
 import 'package:test/test.dart';
 import 'dart:typed_data';
 import 'package:mc_rcon_dart/mc_rcon_dart.dart' as mc_rcon;


### PR DESCRIPTION
This one is supposed to be merged after #2.

It is a "bigger" change in the sense that it will start to give analyzer errors, making it impossible to compile without fixing the type. But it would only do so if anyone is using the callback wrong, and it would then stop getting to a run-time error.

I've only made the addition of a `typedef` for the `onData` callback and used it wherever I could find that being used.

Of course, also updated the changelog.

They both could be uploaded in a single change, and this new upload could obviously update a major version, and that is totally up to you. If you ask for any changes, I'll do them.